### PR TITLE
Update JDKs to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 11.0.19_7, 17.0.7_7 ]
+        jdk: [ 11.0.20_8, 17.0.8_7 ]
         android: [ 31, 32, 33, 34 ]
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@
 #
 # Build with custom arguments:
 #
-#   $ ./scripts/build --android 33 --jdk 17.0.7_7
+#   $ ./scripts/build --android 33 --jdk 17.0.8_7
 #
 
 ARG android=33
-ARG jdk=17.0.7_7
+ARG jdk=17.0.8_7
 
 FROM --platform=linux/amd64 saschpe/android-sdk:${android}-jdk${jdk}
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ command-line tools and JDK 11 (or later) as well as the Android Emulator.
 
 The following JDK and Android SDK API level combinations are currently supported:
 
-|    | 11.0.19_7 | 17.0.7_7 |
-|----|-----------|----------|
-| 31 | ✅         | ✅        |
-| 32 | ✅         | ✅        |
-| 33 | ✅         | ✅        |
-| 34 | ✅         | ✅        |
+|    | 11.0 | 17.0 |
+|----|------|------|
+| 31 | ✅   | ✅   |
+| 32 | ✅   | ✅   |
+| 33 | ✅   | ✅   |
+| 34 | ✅   | ✅   |
 
 ## Usage
 


### PR DESCRIPTION
Old tags continue to stay around, add recent JDK releases for automated
builds.
