### PR TITLE
Set up permissions, funding, and Dependabot in GitHub Actions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: saschpe

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: ".github/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   IMAGE: saschpe/android-emulator
   PLATFORMS: linux/amd64
@@ -30,7 +33,7 @@ jobs:
         android: [ 34, 35 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- **Set read-only permissions**: Updated `main.yml` to include `contents: read`, aligning with the principle of least privilege and limiting access scope for workflows.
- **GitHub funding configuration**: Added `FUNDING.yml` to enable sponsorships via the "saschpe" GitHub sponsor account.
- **Dependabot configuration**: Configured Dependabot to automate dependency updates for Gradle, GitHub Actions, and Docker on a weekly schedule, enhancing security and maintainability.

### Checklist

- [ ] Ensure workflows function as expected.
- [ ] Verify funding links in `FUNDING.yml`.