### PR TITLE
Update GitHub Actions permissions and JDK versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
       matrix:
         jdk: [ 17.0.14_7, 21.0.6_7, 22.0.2_9 ]
         android: [ 34, 35 ]
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 17.0.13_11, 21.0.5_11, 22.0.2_9 ]
+        jdk: [ 17.0.14_7, 21.0.6_7, 22.0.2_9 ]
         android: [ 34, 35 ]
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

This pull request includes the following changes to the GitHub Actions workflow:

1. **Set permissions to write for packages**:  
   Added `packages: write` permission to the workflow, ensuring the ability to properly publish or modify packages during execution.

2. **Update JDK versions in the workflow matrix**:  
   Updated to the latest JDK patch versions (17.0.14_7 and 21.0.6_7) for improved stability and compatibility within the CI pipeline.