### PR TITLE
Update JDK version to 23.0.2_7 across workflows and docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 17.0.14_7, 21.0.6_7, 22.0.2_9 ]
+        jdk: [ 17.0.14_7, 21.0.6_7, 23.0.2_7 ]
         android: [ 34, 35 ]
     permissions:
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@
 #
 # Build with custom arguments:
 #
-#   $ ./scripts/build --android 35 --jdk 22.0.2_9
+#   $ ./scripts/build --android 35 --jdk 23.0.2_7
 #
 
 ARG android=35
-ARG jdk=22.0.2_9
+ARG jdk=23.0.2_7
 
 FROM saschpe/android-sdk:${android}-jdk${jdk}
 ARG android

--- a/README.md
+++ b/README.md
@@ -11,28 +11,28 @@ well as the Android Emulator.
 
 ## Android SDK and JDK support
 
-The following JDK and Android SDK API level combinations are currently
+The following JDK (horizontal axis) and Android SDK API level combinations are currently
 available:
 
-|    | 11 | 17 | 21 | 22 |
-|----|----|----|----|----|
-| 31 | ✅  | ✅  |    |    |
-| 32 | ✅  | ✅  | ✅  | ✅  |
-| 33 | ✅  | ✅  | ✅  | ✅  |
-| 34 | ✅  | ✅  | ✅  | ✅  |
-| 35 |    | ✅  | ✅  | ✅  |
+|    | 11 | 17 | 21 | 22 | 23 |
+|----|----|----|----|----|----|
+| 31 | ✅  | ✅  |    |    |    |
+| 32 | ✅  | ✅  | ✅  | ✅  |    |
+| 33 | ✅  | ✅  | ✅  | ✅  |    | 
+| 34 | ✅  | ✅  | ✅  | ✅  | ✅  | 
+| 35 |    | ✅  | ✅  | ✅  | ✅  |
 
 ## Usage
 
 ```shell
-docker pull saschpe/android-emulator:35-jdk21.0.5_11
+docker pull saschpe/android-emulator:35-jdk23.0.2_7
 ```
 
 Use as a base image:
 
 ```Dockerfile
-FROM saschpe/android-emulator:35-jdk21.0.5_11
-RUN sdkmanager --install "cmake;3.22.1"
+FROM saschpe/android-emulator:35-jdk23.0.2_7
+RUN sdkmanager --install "cmake;3.31.5"
 ```
 
 ## Building


### PR DESCRIPTION
### Description

This pull request updates the JDK version to 23.0.2_7 in the GitHub Actions workflows, Dockerfile, and README. These changes ensure compatibility with the latest configurations and maintain consistency across build processes and usage instructions. Additionally, the supported matrix and usage examples in the documentation have been adjusted accordingly.